### PR TITLE
Fix subscription query and type alias

### DIFF
--- a/src/lib/db/queries/queries.ts
+++ b/src/lib/db/queries/queries.ts
@@ -56,7 +56,7 @@ export async function updateOrganizationSubscription(
       ...subscriptionData,
       updatedAt: new Date(),
     })
-    .where(eq(organizations.id, organizationId));
+    .where(eq(subscriptions.organizationId, organizationId));
 }
 
 export async function getUserWithTeam(userId: string) {

--- a/src/lib/db/schema/messages.ts
+++ b/src/lib/db/schema/messages.ts
@@ -26,4 +26,4 @@ export const messageIdReference = (actions?: ReferenceConfig['actions']) => ({
 });
 
 export type Message = InferSelectModel<typeof messages>;
-export type NewMesage = InferInsertModel<typeof messages>;
+export type NewMessage = InferInsertModel<typeof messages>;


### PR DESCRIPTION
## Summary
- fix subscription update query where clause to use subscriptions table
- correct typo in messages schema type alias

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run format:check` *(fails: Cannot find package '@ianvs/prettier-plugin-sort-imports')*

------
https://chatgpt.com/codex/tasks/task_e_68416a4edb7083229cb3206f9a155087